### PR TITLE
De “Wijzig kleur” knop is gewijzigd naar “Kleur bewaren” UC4

### DIFF
--- a/Grocery.App/Views/ChangeColorView.xaml
+++ b/Grocery.App/Views/ChangeColorView.xaml
@@ -13,6 +13,6 @@
 
     <VerticalStackLayout>
         <Editor Text="{Binding GroceryList.Color}" x:Name="newColor"/>
-        <Button Text="wijzig kleur" Command="{Binding ChangeColorCommand}" CommandParameter="{Binding Source={x:Reference newColor}, Path=Text}" />
+        <Button Text="Kleur bewaren" Command="{Binding ChangeColorCommand}" CommandParameter="{Binding Source={x:Reference newColor}, Path=Text}" />
     </VerticalStackLayout>
 </ContentPage>


### PR DESCRIPTION
De “Wijzig kleur” knop is gewijzigd naar “Kleur bewaren” om onduidelijkheden te verkomen.